### PR TITLE
fix: create Query/Mutation struct as public

### DIFF
--- a/juniper-compose-macros/src/lib.rs
+++ b/juniper-compose-macros/src/lib.rs
@@ -135,7 +135,7 @@ fn expand_composite_object<P>(
         expand_impl_graphql_value_async(name, &name_lit, composables.iter());
     quote! {
         #[derive(::std::default::Default)]
-        struct #name;
+        pub struct #name;
         #impl_graphql_type
         #impl_graphql_value
         #impl_graphql_value_async


### PR DESCRIPTION
Hey @nikis05, great job on this crate! Thanks a lot :D

That PR is just a little update to create the root `Query` / `Mutation` as public, if you want to use it in another crate inside of your project :)

After this update, everything is working like a charm, thanks again :D