### PR TITLE
fix: support juniper master version

### DIFF
--- a/juniper-compose/Cargo.toml
+++ b/juniper-compose/Cargo.toml
@@ -11,5 +11,5 @@ repository = "https://github.com/nikis05/juniper-compose"
 keywords = ["juniper", "compose", "merge"]
 
 [dependencies]
-juniper = { version = "0.15.9" }
+juniper = { git = "https://github.com/graphql-rust/juniper", branch = "master" }
 juniper-compose-macros = { version = "0.0.3", path = "../juniper-compose-macros" }

--- a/juniper-compose/src/lib.rs
+++ b/juniper-compose/src/lib.rs
@@ -137,7 +137,7 @@ pub fn type_to_owned<'a>(ty: &Type<'a>) -> Type<'static> {
     match ty {
         Type::Named(name) => Type::Named(Cow::Owned(name.to_string())),
         Type::NonNullNamed(name) => Type::NonNullNamed(Cow::Owned(name.to_string())),
-        Type::List(inner) => Type::List(Box::new(type_to_owned(inner))),
-        Type::NonNullList(inner) => Type::NonNullList(Box::new(type_to_owned(inner))),
+        Type::List(inner, expected_size) => Type::List(Box::new(type_to_owned(inner)), *expected_size),
+        Type::NonNullList(inner, expected_size) => Type::NonNullList(Box::new(type_to_owned(inner)), *expected_size),
     }
 }


### PR DESCRIPTION
Fixes new ast types definition from `master` branch in `juniper` when using like: 
`juniper = { git = "https://github.com/graphql-rust/juniper", branch = "master" }`

I am very new to Rust ecosistem but i imagine that mergin it to `master` (without doing a new release) could break possible fixes and releases in the future before `juniper` releases a new version so, i don't know how to proceed exactly.